### PR TITLE
add circulation mode

### DIFF
--- a/custom_components/solvis_modbus/const.py
+++ b/custom_components/solvis_modbus/const.py
@@ -129,4 +129,11 @@ REGISTERS = [
         device_class="speed",
         state_class="measurement",
     ),
+    ModbusFieldConfig(
+        name="circulation_mode",
+        address=2049,
+        unit="",
+        device_class= None,
+        state_class="state",
+    ),
 ]

--- a/custom_components/solvis_modbus/translations/de.json
+++ b/custom_components/solvis_modbus/translations/de.json
@@ -55,6 +55,9 @@
       },
       "domestic_water_flow": {
         "name": "Brauchwasser Durchfluss"
+      },
+      "circulation_mode": {
+        "name": "Zirkulation Modus"
       }
     }
   }

--- a/custom_components/solvis_modbus/translations/en.json
+++ b/custom_components/solvis_modbus/translations/en.json
@@ -55,6 +55,9 @@
       },
       "domestic_water_flow": {
         "name": "Domestic water flow"
+      },
+      "circulation_mode": {
+        "name": "Circulation mode"
       }
     }
   }


### PR DESCRIPTION
Hallo,
ich habe soeben aus der Modbus-Anleitung die Abfrage für den circulation mode eingefügt.
Bin in HASS neu und auch im git mergen, deswegen schonmal sorry für etwaige Fehler.
Ob ich device_class und state_class richtig gesetzt habe weiß ich leider nicht.
Laut Anleitung wird 2049 "Zirkulation Betriebsart" zurück gegeben mit 1: Aus,  2:Puls,3: Temp,  4: Warten
würde wenn das so funktioniert die nächsten Tage noch andere Einträge ergänzen, die in meiner Heizung genutzt werden