### PR TITLE
Add sensors + modbus registers for heat pump electric/thermal power

### DIFF
--- a/custom_components/solvis_modbus/__init__.py
+++ b/custom_components/solvis_modbus/__init__.py
@@ -1,5 +1,6 @@
 """Solvis integration."""
 
+import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
@@ -24,6 +25,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(entry.entry_id, {})
 
+    # Add update listener for config change
+    unsub_options_update_listener = entry.add_update_listener(async_update_options)
+    # Store the listener in the entry data for later cleanup
+    hass_data = dict(entry.data)
+    hass_data["unsub_options_update_listener"] = unsub_options_update_listener
+    hass.data[DOMAIN][entry.entry_id] = hass_data
+
     # Create coordinator for polling
     coordinator = PollingCoordinator(hass, address)
     await coordinator.async_config_entry_first_refresh()
@@ -33,3 +41,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Update options."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+    # Remove options_update_listener.
+    hass.data[DOMAIN][entry.entry_id]["unsub_options_update_listener"]()
+
+    # Remove config entry from domain.
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/solvis_modbus/config_flow.py
+++ b/custom_components/solvis_modbus/config_flow.py
@@ -23,6 +23,9 @@ _LOGGER = logging.getLogger(__name__)
 class SolvisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle config flow for Solvis Modbus devices."""
 
+    VERSION = 2
+    MINOR_VERSION = 1
+
     def __init__(self) -> None:
         _LOGGER.info("Initialize config flow for %s", DOMAIN)
         self._address: str | None = None

--- a/custom_components/solvis_modbus/const.py
+++ b/custom_components/solvis_modbus/const.py
@@ -1,11 +1,23 @@
 """Constants for the Solvis Modbus integration."""
 
 from dataclasses import dataclass
+from enum import Flag
+from typing import Final
 
 DOMAIN = "solvis_modbus"
 MANUFACTURER = "Solvis"
 
 DATA_COORDINATOR = "coordinator"
+
+CONF_HEATER_TYPE: Final = "heater_type"
+
+
+class HeaterType(Flag):
+    """Enum for heater types."""
+
+    GAS_BOILER = 1
+    HEAT_PUMP = 2
+
 
 @dataclass(frozen=True)
 class ModbusFieldConfig:
@@ -16,16 +28,9 @@ class ModbusFieldConfig:
     state_class: str
     multiplier: float = 0.1
 
-PORT = 502
-REGISTERS = [
-    ModbusFieldConfig(
-        name="gas_power",
-        address=33539,
-        unit="kW",
-        device_class="power",
-        state_class="measurement",
-    ),
 
+PORT = 502
+DEFAULT_REGISTERS = [
     ModbusFieldConfig(
         name="outdoor_air_temp",
         address=33033,
@@ -40,7 +45,6 @@ REGISTERS = [
         device_class="temperature",
         state_class="measurement",
     ),
-
     ModbusFieldConfig(
         name="cold_water_temp",
         address=33034,
@@ -63,7 +67,6 @@ REGISTERS = [
         device_class="temperature",
         state_class="measurement",
     ),
-
     ModbusFieldConfig(
         name="solar_water_temp",
         address=33030,
@@ -85,7 +88,6 @@ REGISTERS = [
         device_class="temperature",
         state_class="measurement",
     ),
-
     ModbusFieldConfig(
         name="tank_layer1_water_temp",
         address=33026,
@@ -114,7 +116,6 @@ REGISTERS = [
         device_class="temperature",
         state_class="measurement",
     ),
-
     ModbusFieldConfig(
         name="solar_water_flow",
         address=33040,
@@ -129,7 +130,20 @@ REGISTERS = [
         device_class="speed",
         state_class="measurement",
     ),
+]
 
+
+GAS_REGISTERS = [
+    ModbusFieldConfig(
+        name="gas_power",
+        address=33539,
+        unit="kW",
+        device_class="power",
+        state_class="measurement",
+    ),
+]
+
+HEAT_PUMP_REGISTERS = [
     ModbusFieldConfig(
         name="heat_pump_thermal_power",
         address=33544,
@@ -144,4 +158,11 @@ REGISTERS = [
         device_class="power",
         state_class="measurement",
     ),
+]
+
+
+REGISTERS = [
+    *DEFAULT_REGISTERS,
+    *GAS_REGISTERS,
+    *HEAT_PUMP_REGISTERS,
 ]

--- a/custom_components/solvis_modbus/const.py
+++ b/custom_components/solvis_modbus/const.py
@@ -129,4 +129,19 @@ REGISTERS = [
         device_class="speed",
         state_class="measurement",
     ),
+
+    ModbusFieldConfig(
+        name="heat_pump_thermal_power",
+        address=33544,
+        unit="kW",
+        device_class="power",
+        state_class="measurement",
+    ),
+    ModbusFieldConfig(
+        name="heat_pump_electric_power",
+        address=33545,
+        unit="kW",
+        device_class="power",
+        state_class="measurement",
+    ),
 ]

--- a/custom_components/solvis_modbus/sensor.py
+++ b/custom_components/solvis_modbus/sensor.py
@@ -17,10 +17,20 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 
-from .const import DATA_COORDINATOR, DOMAIN, MANUFACTURER, REGISTERS
+from .const import (
+    DATA_COORDINATOR,
+    DOMAIN,
+    GAS_REGISTERS,
+    HEAT_PUMP_REGISTERS,
+    MANUFACTURER,
+    DEFAULT_REGISTERS,
+    CONF_HEATER_TYPE,
+    HeaterType,
+)
 from .coordinator import PollingCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -42,7 +52,14 @@ async def async_setup_entry(
     # Add sensors
     sensors_to_add = []
 
-    for register in REGISTERS:
+    heater_types = HeaterType(entry.options.get(CONF_HEATER_TYPE))
+    registers = DEFAULT_REGISTERS.copy()
+    if heater_types & HeaterType.GAS_BOILER:
+        registers.extend(GAS_REGISTERS)
+    if heater_types & HeaterType.HEAT_PUMP:
+        registers.extend(HEAT_PUMP_REGISTERS)
+
+    for register in registers:
         sensors_to_add.append(
             SolvisSensor(
                 hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR],

--- a/custom_components/solvis_modbus/translations/de.json
+++ b/custom_components/solvis_modbus/translations/de.json
@@ -14,6 +14,13 @@
       }
     }
   },
+  "options": {
+    "init": {
+      "data": {
+        "type": "Heizungsarten"
+      }
+    }
+  },
   "selector": {
     "heater_type": {
       "options": {

--- a/custom_components/solvis_modbus/translations/de.json
+++ b/custom_components/solvis_modbus/translations/de.json
@@ -55,6 +55,12 @@
       },
       "domestic_water_flow": {
         "name": "Brauchwasser Durchfluss"
+      },
+      "heat_pump_thermal_power": {
+        "name": "Wärmepumpe thermische Leistung"
+      },
+      "heat_pump_electric_power": {
+        "name": "Wärmepumpen elektrische Leistung"
       }
     }
   }

--- a/custom_components/solvis_modbus/translations/de.json
+++ b/custom_components/solvis_modbus/translations/de.json
@@ -6,6 +6,19 @@
           "ip_address": "IP Adresse",
           "name": "Name"
         }
+      },
+      "heater_type": {
+        "data": {
+          "type": "Heizungsarten"
+        }
+      }
+    }
+  },
+  "selector": {
+    "heater_type": {
+      "options": {
+        "GAS_BOILER": "Gasheizung",
+        "HEAT_PUMP": "Wärmepumpe"
       }
     }
   },

--- a/custom_components/solvis_modbus/translations/en.json
+++ b/custom_components/solvis_modbus/translations/en.json
@@ -55,6 +55,12 @@
       },
       "domestic_water_flow": {
         "name": "Domestic water flow"
+      },
+      "heat_pump_thermal_power": {
+        "name": "Heat pump thermal power"
+      },
+      "heat_pump_electric_power": {
+        "name": "Heat pump electric power"
       }
     }
   }

--- a/custom_components/solvis_modbus/translations/en.json
+++ b/custom_components/solvis_modbus/translations/en.json
@@ -6,6 +6,19 @@
           "ip_address": "IP-Address",
           "name": "Name"
         }
+      },
+      "heater_type": {
+        "data": {
+          "type": "Heater Types"
+        }
+      }
+    }
+  },
+  "selector": {
+    "heater_type": {
+      "options": {
+        "GAS_BOILER": "Gas Boiler",
+        "HEAT_PUMP": "Heat Pump"
       }
     }
   },

--- a/custom_components/solvis_modbus/translations/en.json
+++ b/custom_components/solvis_modbus/translations/en.json
@@ -14,6 +14,13 @@
       }
     }
   },
+  "options": {
+    "init": {
+      "data": {
+        "type": "Heater Types"
+      }
+    }
+  },
   "selector": {
     "heater_type": {
       "options": {


### PR DESCRIPTION
I added the Modbus registers for heat pump electric and thermal power. They seem not to be documented in the Modbus register, but I tried some addresses and found that these match the measurements shown on the remote.

They should probably be 0 if no heat pump is connected, but I could not test this. I could modify the config_flow so you can select whether you use a heat pump or not, but I thought adding two additional sensors being 0 does not really hurt for users without a heat pump.