### PR TITLE
fix solar_water_flow and domestic_water_flow unit and device_class

### DIFF
--- a/custom_components/solvis_modbus/const.py
+++ b/custom_components/solvis_modbus/const.py
@@ -118,15 +118,15 @@ REGISTERS = [
     ModbusFieldConfig(
         name="solar_water_flow",
         address=33040,
-        unit="l/min",
-        device_class="speed",
+        unit="L/min",
+        device_class="volume_flow_rate",
         state_class="measurement",
     ),
     ModbusFieldConfig(
         name="domestic_water_flow",
         address=33041,
-        unit="l/min",
-        device_class="speed",
+        unit="L/min",
+        device_class="volume_flow_rate",
         state_class="measurement",
     ),
 ]


### PR DESCRIPTION
Unit should be L/min not l/min. device_class should be volume_flow_rate not speed (https://www.home-assistant.io/integrations/sensor#device-class)


fixes

```
2025-04-08 14:16:50.578 WARNING (MainThread) [asyncio] Executing <Handle _SelectorTransport._add_reader(34, <bound method..., bufsize=0>>>) created at /usr/local/lib/python3.13/asyncio/selector_events.py:1216> took 0.133 seconds
2025-04-08 14:17:09.876 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.asdf_solar_durchfluss (<class 'custom_components.solvis_modbus.sensor.SolvisSensor'>) is using native unit of measurement 'l/min' which is not a valid unit for the device class ('speed') it is using; expected one of ['m/s', 'ft/s', 'mm/h', 'mph', 'in/d', 'in/s', 'in/h', 'Beaufort', 'km/h', 'mm/d', 'mm/s', 'kn']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/Patrick762/hassio-solvis-modbus/issues
```

