### PR TITLE
Move Solar to own heater_type + add Solar Current Power sensor

### DIFF
--- a/custom_components/solvis_modbus/__init__.py
+++ b/custom_components/solvis_modbus/__init__.py
@@ -66,11 +66,21 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         new_data = {**config_entry.data}
         new_options = {**config_entry.options}
 
-        new_options[CONF_HEATER_TYPE] = HeaterType.GAS_BOILER
+        new_options[CONF_HEATER_TYPE] = HeaterType.GAS_BOILER | HeaterType.SOLAR
         _LOGGER.debug("Adding default heater type to options")
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, minor_version=1, version=2
+        )
+    if config_entry.version == 2:
+        new_data = {**config_entry.data}
+        new_options = {**config_entry.options}
+        if config_entry.minor_version == 1:
+            new_options[CONF_HEATER_TYPE] = (
+                HeaterType(new_options[CONF_HEATER_TYPE]) | HeaterType.SOLAR
+            )
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, options=new_options, minor_version=2, version=2
         )
 
     _LOGGER.info(

--- a/custom_components/solvis_modbus/config_flow.py
+++ b/custom_components/solvis_modbus/config_flow.py
@@ -24,7 +24,7 @@ class SolvisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle config flow for Solvis Modbus devices."""
 
     VERSION = 2
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         _LOGGER.info("Initialize config flow for %s", DOMAIN)

--- a/custom_components/solvis_modbus/const.py
+++ b/custom_components/solvis_modbus/const.py
@@ -19,6 +19,7 @@ class HeaterType(Flag):
 
     GAS_BOILER = 1
     HEAT_PUMP = 2
+    SOLAR = 4
 
 
 @dataclass(frozen=True)
@@ -70,27 +71,6 @@ DEFAULT_REGISTERS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     ModbusFieldConfig(
-        name="solar_water_temp",
-        address=33030,
-        unit="°C",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusFieldConfig(
-        name="solar_heat_exchanger_in_water_temp",
-        address=33029,
-        unit="°C",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusFieldConfig(
-        name="solar_heat_exchanger_out_water_temp",
-        address=33028,
-        unit="°C",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusFieldConfig(
         name="tank_layer1_water_temp",
         address=33026,
         unit="°C",
@@ -116,13 +96,6 @@ DEFAULT_REGISTERS = [
         address=33024,
         unit="°C",
         device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusFieldConfig(
-        name="solar_water_flow",
-        address=33040,
-        unit="L/min",
-        device_class="volume_flow_rate",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     ModbusFieldConfig(
@@ -162,9 +135,48 @@ HEAT_PUMP_REGISTERS = [
     ),
 ]
 
+SOLAR_REGISTERS = [
+    ModbusFieldConfig(
+        name="solar_water_temp",
+        address=33030,
+        unit="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ModbusFieldConfig(
+        name="solar_heat_exchanger_in_water_temp",
+        address=33029,
+        unit="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ModbusFieldConfig(
+        name="solar_heat_exchanger_out_water_temp",
+        address=33028,
+        unit="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ModbusFieldConfig(
+        name="solar_water_flow",
+        address=33040,
+        unit="L/min",
+        device_class="volume_flow_rate",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ModbusFieldConfig(
+        name="solar_power",
+        address=33543,
+        unit="kW",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+]
+
 
 REGISTERS = [
     *DEFAULT_REGISTERS,
     *GAS_REGISTERS,
     *HEAT_PUMP_REGISTERS,
+    *SOLAR_REGISTERS,
 ]

--- a/custom_components/solvis_modbus/sensor.py
+++ b/custom_components/solvis_modbus/sensor.py
@@ -25,6 +25,7 @@ from .const import (
     MANUFACTURER,
     DEFAULT_REGISTERS,
     CONF_HEATER_TYPE,
+    SOLAR_REGISTERS,
     HeaterType,
 )
 from .coordinator import PollingCoordinator
@@ -58,6 +59,8 @@ async def async_setup_entry(
         registers.extend(GAS_REGISTERS)
     if heater_types & HeaterType.HEAT_PUMP:
         registers.extend(HEAT_PUMP_REGISTERS)
+    if heater_types & HeaterType.SOLAR:
+        registers.extend(SOLAR_REGISTERS)
 
     for register in registers:
         sensors_to_add.append(

--- a/custom_components/solvis_modbus/translations/de.json
+++ b/custom_components/solvis_modbus/translations/de.json
@@ -25,7 +25,8 @@
     "heater_type": {
       "options": {
         "GAS_BOILER": "Gasheizung",
-        "HEAT_PUMP": "Wärmepumpe"
+        "HEAT_PUMP": "Wärmepumpe",
+        "SOLAR": "Solarthermie Panele"
       }
     }
   },
@@ -57,6 +58,9 @@
       },
       "solar_heat_exchanger_out_water_temp": {
         "name": "Solar Temperatur Wärmetauscher Ausgang"
+      },
+      "solar_power": {
+        "name": "Solar Aktuelle Wärme Leistung"
       },
       "tank_layer1_water_temp": {
         "name": "Kessel Schicht 1 Temperatur"

--- a/custom_components/solvis_modbus/translations/en.json
+++ b/custom_components/solvis_modbus/translations/en.json
@@ -25,7 +25,8 @@
     "heater_type": {
       "options": {
         "GAS_BOILER": "Gas Boiler",
-        "HEAT_PUMP": "Heat Pump"
+        "HEAT_PUMP": "Heat Pump",
+        "SOLAR": "Solar Panels"
       }
     }
   },
@@ -57,6 +58,9 @@
       },
       "solar_heat_exchanger_out_water_temp": {
         "name": "Solar temperature heat exchanger output"
+      },
+      "solar_power": {
+        "name": "Solar current heating power"
       },
       "tank_layer1_water_temp": {
         "name": "Tank layer 1 water temperature"

--- a/custom_components/solvis_modbus/translations/pt.json
+++ b/custom_components/solvis_modbus/translations/pt.json
@@ -9,6 +9,15 @@
       }
     }
   },
+  "selector": {
+    "heater_type": {
+      "options": {
+        "GAS_BOILER": "Caldeira a Gás",
+        "HEAT_PUMP": "Bomba de Calor",
+        "SOLAR": "Painéis Solares"
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "gas_power": {
@@ -37,6 +46,9 @@
       },
       "solar_heat_exchanger_out_water_temp": {
         "name": "Temperatura de saída do permutador de calor solar"
+      },
+      "solar_power": {
+        "name": "Potência solar atual"
       },
       "tank_layer1_water_temp": {
         "name": "Temperatura da água no tanque - camada 1"


### PR DESCRIPTION
I moved solar to its own heater_type so users can disable the sensors if they don't use solar panels.


I found the (not documented) solar Current Power Modbus address (at least for my setup) . I think this sensor is quite useful, so I added it as well